### PR TITLE
chore: release v0.4.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0-rc.0] - 2025-06-14
+
+### 🚀 Added
+
+- Add pre-release versions support by @powerman in [#29]
+
+### New Contributors
+
+- @powerman made their first contribution in [#29](https://github.com/powerman/workflows/pull/29)
+
+[0.4.0-rc.0]: https://github.com/powerman/workflows/compare/v0.3.0..v0.4.0-rc.0
+[#29]: https://github.com/powerman/workflows/pull/29
+
 ## [0.3.0] - 2025-06-14
 
 ### 🔔 Changed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ env:
 
 jobs:
   release-pr:
-    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.3.0
+    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.4.0-rc.0
     # with:
     #   target_branch: 'main'                 # Default: repository default branch
     #   pr_branch: 'release-pr'               # Default: 'release-pr'
@@ -185,7 +185,7 @@ Update additional files when the version changes:
 ```yaml
 jobs:
   release-pr:
-    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.3.0
+    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.4.0-rc.0
     with:
       version_cmd: |
         # Strip 'v' prefix from version and update the version in package files.
@@ -213,7 +213,7 @@ env:
 
 jobs:
   release-pr:
-    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.3.0
+    uses: powerman/workflows/.github/workflows/release-pr.yml@v0.4.0-rc.0
     secrets:
       TOKEN: ${{ secrets.RELEASE_TOKEN }}
 


### PR DESCRIPTION

### 🚀 Added

- Add pre-release versions support by @powerman in [#29]

### New Contributors

- @powerman made their first contribution in [#29](https://github.com/powerman/workflows/pull/29)

[0.4.0-rc.0]: https://github.com/powerman/workflows/compare/v0.3.0..v0.4.0-rc.0
[#29]: https://github.com/powerman/workflows/pull/29