### PR TITLE
chore: release v0.4.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add pre-release versions support by @powerman in [#29]
 
-### New Contributors
-
-- @powerman made their first contribution in [#29](https://github.com/powerman/workflows/pull/29)
-
 [0.4.0-rc.0]: https://github.com/powerman/workflows/compare/v0.3.0..v0.4.0-rc.0
 [#29]: https://github.com/powerman/workflows/pull/29
 


### PR DESCRIPTION

### 🚀 Added

- Add pre-release versions support by @powerman in [#29]

[0.4.0-rc.0]: https://github.com/powerman/workflows/compare/v0.3.0..v0.4.0-rc.0
[#29]: https://github.com/powerman/workflows/pull/29